### PR TITLE
Add dri access to fix O365Interactive

### DIFF
--- a/org.davmail.DavMail.yaml
+++ b/org.davmail.DavMail.yaml
@@ -6,6 +6,7 @@ finish-args:
   # X11 access
   - --socket=x11
   - --share=ipc
+  - --device=dri
   # Network access
   - --share=network
   - --env=JAVA_HOME=jdk


### PR DESCRIPTION
Otherwise, it fails with the following console messages:

MESA: error: Failed to query drm device.
libEGL warning: egl: failed to create dri2 screen